### PR TITLE
chore: remove unused service parameters and imports

### DIFF
--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -13,7 +13,7 @@ export interface ListParams {
   [key: string]: unknown
 }
 
-export function createBaseService<T, TInput>(endpoint: string, useSlug = false) {
+export function createBaseService<T, TInput>(endpoint: string) {
   const normalizedEndpoint = endpoint.endsWith('/') ? endpoint : `${endpoint}/`
 
   return {

--- a/src/services/testimonial.ts
+++ b/src/services/testimonial.ts
@@ -1,5 +1,4 @@
 import { createBaseService, type PaginatedResponse } from './baseService'
-import api from './api'
 
 export interface Testimonial {
   id: number


### PR DESCRIPTION
### Motivation
- Remove dead code and fix lint warnings by eliminating an unused parameter and an unused import in the shared service layer.

### Description
- Removed the unused `useSlug` parameter from `createBaseService` in `src/services/baseService.ts` and removed an unused `api` import from `src/services/testimonial.ts` to simplify the API and satisfy lint rules.

### Testing
- Ran `npm run lint` (success) and `npm run build` (success); `npm run test:unit` exited with "No test files found" and there is no `test` script defined in `package.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bcfb12c20833389d46cb929e651ab)