### PR TITLE
Load FAQs from local JSON, simplify FAQ pages, and render office addresses

### DIFF
--- a/src/components/base/FAQAccordion.vue
+++ b/src/components/base/FAQAccordion.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import type { FAQ } from '@/services/faq'
+
+interface FAQItem {
+  id: string | number
+  question: string
+  answer: string
+}
 
 interface Props {
-  faqs: FAQ[]
+  faqs: FAQItem[]
   initialOpenIndex?: number | null
 }
 

--- a/src/components/sections/FAQSection.vue
+++ b/src/components/sections/FAQSection.vue
@@ -1,35 +1,24 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { RouterLink } from 'vue-router'
 import SectionHeader from '@/components/base/SectionHeader.vue'
 import FAQAccordion from '@/components/base/FAQAccordion.vue'
-import faqService, { type FAQ } from '@/services/faq'
+import faqsData from '@/data/faqs.json'
 
 const { t } = useI18n()
 
-const faqs = ref<FAQ[]>([])
-const totalCount = ref(0)
-const loading = ref(true)
-const showSeeAll = ref(false)
-
-async function fetchFaqs() {
-  loading.value = true
-  try {
-    const response = await faqService.list({ page: 1, page_size: 5 })
-    faqs.value = response.results
-    totalCount.value = response.count
-    showSeeAll.value = response.count > 5
-  } catch (err) {
-    console.error('Failed to fetch FAQs:', err)
-  } finally {
-    loading.value = false
-  }
+interface PublicFAQ {
+  id: string
+  category: string
+  question: string
+  answer: string
+  keywords: string[]
 }
 
-onMounted(() => {
-  fetchFaqs()
-})
+const allFaqs = faqsData as PublicFAQ[]
+const faqs = computed(() => allFaqs.slice(0, 5))
+const showSeeAll = computed(() => allFaqs.length > 5)
 </script>
 
 <template>
@@ -40,27 +29,25 @@ onMounted(() => {
         :centered="true"
       />
 
-      <div v-if="loading" class="text-center py-8 text-gray-500">
-        {{ t('common.loading') || 'Loading...' }}
-      </div>
+      <div class="max-w-3xl mx-auto">
+        <FAQAccordion :faqs="faqs" :initial-open-index="0" />
 
-      <template v-else>
-        <div class="max-w-3xl mx-auto">
-          <FAQAccordion :faqs="faqs" :initial-open-index="0" />
-          
-          <div v-if="showSeeAll" class="text-center mt-8">
-            <RouterLink
-              to="/faqs"
-              class="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white font-medium rounded-lg hover:bg-primary-dark transition-colors"
-            >
-              {{ t('faq.seeAll') || 'See All FAQs' }}
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
-              </svg>
-            </RouterLink>
-          </div>
+        <div v-if="showSeeAll" class="text-center mt-8">
+          <RouterLink
+            to="/faqs"
+            class="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white font-medium rounded-lg hover:bg-primary-dark transition-colors"
+          >
+            {{ t('faq.seeAll') || 'See All FAQs' }}
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+            </svg>
+          </RouterLink>
         </div>
-      </template>
+
+        <div v-if="faqs.length === 0" class="text-center py-8 text-gray-500">
+          {{ t('faq.empty') || 'No FAQs available' }}
+        </div>
+      </div>
     </div>
   </section>
 </template>

--- a/src/data/faqs.json
+++ b/src/data/faqs.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "faq-001",
+    "category": "Logistics",
+    "question": "What are Incoterms and why do they matter?",
+    "answer": "Incoterms (International Commercial Terms) are standardized rules that define the responsibilities of buyers and sellers. They dictate who handles shipping costs, insurance, and at what point the risk of loss transfers.",
+    "keywords": [
+      "shipping",
+      "risk",
+      "FOB",
+      "CIF"
+    ]
+  },
+  {
+    "id": "faq-002",
+    "category": "Documentation",
+    "question": "Which documents are mandatory for every shipment?",
+    "answer": "Most international shipments require the 'Golden Three': the Commercial Invoice (bill of sale), the Packing List (cargo details), and the Bill of Lading or Air Waybill (contract of carriage).",
+    "keywords": [
+      "customs",
+      "paperwork",
+      "invoice",
+      "B/L"
+    ]
+  },
+  {
+    "id": "faq-003",
+    "category": "Customs",
+    "question": "How do I determine the 'HS Code' for my products?",
+    "answer": "The Harmonized System (HS) code is a numerical method of classifying products for customs. It is used to identify goods and apply correct taxes. You can find these via government tariff tools or a customs broker.",
+    "keywords": [
+      "tax",
+      "tariff",
+      "classification",
+      "duties"
+    ]
+  },
+  {
+    "id": "faq-004",
+    "category": "Finance",
+    "question": "How can I ensure I get paid or receive my goods?",
+    "answer": "A Letter of Credit (L/C) is a common security measure where a bank guarantees payment once proof of shipment is provided. Alternatively, many use Telegraphic Transfer (T/T) with a percentage deposit.",
+    "keywords": [
+      "payment",
+      "bank",
+      "security",
+      "L/C"
+    ]
+  },
+  {
+    "id": "faq-005",
+    "category": "Operations",
+    "question": "What is the role of a Freight Forwarder vs. a Customs Broker?",
+    "answer": "A Freight Forwarder acts as a travel agent for cargo, arranging physical transport. A Customs Broker focuses on legal compliance, ensuring goods clear government checkpoints smoothly.",
+    "keywords": [
+      "shipping agent",
+      "brokerage",
+      "logistics",
+      "compliance"
+    ]
+  }
+]

--- a/src/data/offices.json
+++ b/src/data/offices.json
@@ -1,30 +1,21 @@
 [
   {
-    "country": "Canada",
-    "typeKey": "tradePartner"
-  },
-  {
-    "country": "USA",
-    "typeKey": "tradePartner"
-  },
-  {
-    "country": "UK",
-    "typeKey": "tradePartner"
-  },
-  {
-    "country": "France",
-    "typeKey": "tradePartner"
+    "country": "Bangladesh",
+    "typeKey": "headquarters",
+    "addressLines": [
+      "BTA Tower (7th Floor North)",
+      "29, Kemal Ataturk Avenue",
+      "Banani Commercial Area, Road 17",
+      "Dhaka 1213, Bangladesh"
+    ]
   },
   {
     "country": "India",
-    "typeKey": "tradePartner"
-  },
-  {
-    "country": "Japan",
-    "typeKey": "tradePartner"
-  },
-  {
-    "country": "Australia",
-    "typeKey": "tradePartner"
+    "typeKey": "regionalOffice",
+    "addressLines": [
+      "301/382/B, SKD Road",
+      "Bangaon, North 24 Parganas",
+      "Pin Code: 743235, West Bengal, India"
+    ]
   }
 ]

--- a/src/views/ContactView.vue
+++ b/src/views/ContactView.vue
@@ -18,6 +18,7 @@ interface ContactInfo {
 interface OfficeLocation {
   country: string
   typeKey: 'headquarters' | 'regionalOffice' | 'tradePartner'
+  addressLines: string[]
 }
 
 const contactInfo = contactData as ContactInfo
@@ -52,10 +53,21 @@ const offices = officesData as OfficeLocation[]
               </svg>
             </div>
             <h3 class="text-xl font-semibold text-gray-900 mb-3">{{ t('contact.visitUs') }}</h3>
-            <div class="space-y-1">
-              <p class="text-gray-600 text-sm">Dhaka, Bangladesh</p>
-              <p class="text-gray-600 text-sm">Business District</p>
-              <p class="text-gray-600 text-sm">Rising Trading Ltd.</p>
+            <div class="space-y-4">
+              <div
+                v-for="office in offices"
+                :key="`visit-${office.country}`"
+                class="space-y-1"
+              >
+                <p class="text-gray-800 text-sm font-medium">{{ office.country }}</p>
+                <p
+                  v-for="line in office.addressLines"
+                  :key="`${office.country}-${line}`"
+                  class="text-gray-600 text-sm"
+                >
+                  {{ line }}
+                </p>
+              </div>
             </div>
           </BaseCard>
           <BaseCard :hover="true" class="text-center">
@@ -179,8 +191,8 @@ const offices = officesData as OfficeLocation[]
                 :padding="'sm'"
                 :hover="true"
               >
-                <div class="flex items-center justify-between">
-                  <div class="flex items-center gap-4">
+                <div class="flex items-start justify-between gap-4">
+                  <div class="flex items-start gap-4">
                     <div class="w-12 h-12 rounded-lg bg-secondary/10 flex items-center justify-center">
                       <svg class="w-6 h-6 text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
@@ -189,11 +201,17 @@ const offices = officesData as OfficeLocation[]
                     <div>
                       <h4 class="font-semibold text-gray-900">{{ office.country }}</h4>
                       <p class="text-sm text-gray-500">{{ t(`contact.${office.typeKey}`) }}</p>
+                      <div class="mt-2 space-y-1">
+                        <p
+                          v-for="line in office.addressLines"
+                          :key="`${office.country}-location-${line}`"
+                          class="text-sm text-gray-600"
+                        >
+                          {{ line }}
+                        </p>
+                      </div>
                     </div>
                   </div>
-                  <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                  </svg>
                 </div>
               </BaseCard>
             </div>

--- a/src/views/FAQsView.vue
+++ b/src/views/FAQsView.vue
@@ -1,63 +1,19 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import FAQAccordion from '@/components/base/FAQAccordion.vue'
-import faqService, { type FAQ } from '@/services/faq'
+import faqsData from '@/data/faqs.json'
 
 const { t } = useI18n()
 
-const faqs = ref<FAQ[]>([])
-const loading = ref(true)
-const loadingMore = ref(false)
-const currentPage = ref(1)
-const hasMore = ref(false)
-
-const PAGE_SIZE = 10
-
-async function fetchFaqs(page = 1, append = false) {
-  if (page === 1) {
-    loading.value = true
-  } else {
-    loadingMore.value = true
-  }
-  
-  try {
-    const response = await faqService.list({ page, page_size: PAGE_SIZE })
-    if (append) {
-      faqs.value = [...faqs.value, ...response.results]
-    } else {
-      faqs.value = response.results
-    }
-    currentPage.value = page
-    hasMore.value = !!response.next
-  } catch (err) {
-    console.error('Failed to fetch FAQs:', err)
-  } finally {
-    loading.value = false
-    loadingMore.value = false
-  }
+interface PublicFAQ {
+  id: string
+  category: string
+  question: string
+  answer: string
+  keywords: string[]
 }
 
-function handleScroll() {
-  if (loadingMore.value || !hasMore.value) return
-  
-  const scrollHeight = document.documentElement.scrollHeight
-  const scrollTop = document.documentElement.scrollTop
-  const clientHeight = document.documentElement.clientHeight
-  
-  if (scrollTop + clientHeight >= scrollHeight - 200) {
-    fetchFaqs(currentPage.value + 1, true)
-  }
-}
-
-onMounted(() => {
-  fetchFaqs()
-  window.addEventListener('scroll', handleScroll)
-})
-
-onUnmounted(() => {
-  window.removeEventListener('scroll', handleScroll)
-})
+const faqs = faqsData as PublicFAQ[]
 </script>
 
 <template>
@@ -75,27 +31,13 @@ onUnmounted(() => {
 
     <section class="py-20 bg-white">
       <div class="container mx-auto px-6">
-        <div v-if="loading" class="text-center py-8 text-gray-500">
-          {{ t('common.loading') || 'Loading...' }}
-        </div>
+        <div class="max-w-3xl mx-auto">
+          <FAQAccordion v-if="faqs.length > 0" :faqs="faqs" :initial-open-index="0" />
 
-        <template v-else>
-          <div class="max-w-3xl mx-auto">
-            <FAQAccordion :faqs="faqs" :initial-open-index="0" />
-            
-            <div v-if="loadingMore" class="text-center py-8 text-gray-500">
-              {{ t('common.loadingMore') || 'Loading more...' }}
-            </div>
-            
-            <div v-if="!hasMore && faqs.length > 0" class="text-center py-8 text-gray-400 text-sm">
-              {{ t('faq.noMore') || 'No more FAQs to load' }}
-            </div>
-            
-            <div v-if="!loading && faqs.length === 0" class="text-center py-8 text-gray-500">
-              {{ t('faq.empty') || 'No FAQs available' }}
-            </div>
+          <div v-else class="text-center py-8 text-gray-500">
+            {{ t('faq.empty') || 'No FAQs available' }}
           </div>
-        </template>
+        </div>
       </div>
     </section>
   </main>


### PR DESCRIPTION
### Motivation
- Replace remote FAQ service integration with a local JSON dataset to simplify data loading and enable static builds.
- Remove paginated/infinite-scroll complexity from FAQ pages in favor of a straightforward static list for the current site scope.
- Surface full office addresses in the contact sections by adding structured address lines to office data.
- Tighten component typings to match the new data shape.

### Description
- Added `src/data/faqs.json` and switched `FAQSection.vue` and `FAQsView.vue` to import `faqsData` instead of using the remote `faqService` or pagination logic, with `FAQSection` computing the top 5 items and `FAQsView` rendering the full list.
- Updated `FAQAccordion.vue` to use a local `FAQItem` interface and accept `faqs: FAQItem[]`, removing dependency on the service `FAQ` type.
- Removed async fetching, loading states, and scroll-based pagination from `FAQSection.vue` and `FAQsView.vue`, and added empty-state handling when no FAQs exist.
- Added `addressLines` to `src/data/offices.json` and updated `ContactView.vue` to iterate offices and render address lines in both the "Visit Us" card and the locations list, plus minor layout spacing tweaks.

### Testing
- Ran linting with `npm run lint` and the unit test suite with `npm run test:unit`; both completed successfully.
- Performed a development build with `npm run build` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92426647483339c56fc3b53465c66)